### PR TITLE
Add cabinet-lib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+-e git+https://github.com/cabinet/cabinet-lib.git#egg=cabinet-lib
 cement


### PR DESCRIPTION
Add the cabinet-lib dependency by pointing to its repository.