### PR TITLE
Add prompt for credentials and conf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,112 @@
 # Cabinet CLI
 
 An CLI for Cabinet.
+
+## Installation
+
+```
+pip install -r requiremen.txt
+```
+
+## Configuration
+
+By default, the cli will read the configuration file located on `~/.config/cabinet/cli.ini`. So far, it only the following parameters are configurable:
+
+* `account` : The users account.
+* `default_vault` : The default vault name to be used if none is specified.
+
+The configuration file (`cli.ini`) looks like:
+
+```ini
+[Credentials]
+# The cabinet account
+account=facu
+# The default vault to be used if none is specified
+default_vault=awesome-vault
+```
+
+## CLI Sections
+
+The command containse two sections:
+
+* `search` : For seeking for a stored item
+* `item` : For adding and getting an specific item
+
+```profile
+usage: cabinet (sub-commands ...) [options ...] {arguments ...}
+
+Cabinet's cli client for managing vaults.
+
+commands:
+
+  item
+    Item Controller
+
+  search
+    Search Controller
+
+optional arguments:
+  -h, --help     show this help message and exit
+  --debug        toggle debug output
+  --quiet        suppress all output
+  -v, --version  show program's version number and exit
+```
+
+### Searching
+
+```profile
+usage: cabinet (sub-commands ...) [options ...] {arguments ...}
+
+Search Controller
+
+commands:
+
+  default
+    Get all the items in the vault.
+
+positional arguments:
+  extra_arguments
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               toggle debug output
+  --quiet               suppress all output
+  -a ACCOUNT, --account ACCOUNT
+                        Use this account to authenticate
+  -v VAULT, --vault VAULT
+                        Use this vault
+  -s, --show-tags       Show items with tags.
+  -t TAG, --tag TAG     Filter by tag
+  --tags TAGS           Filter by multiple tags
+```
+
+### Adding/Getting
+
+```profile
+usage: cabinet (sub-commands ...) [options ...] {arguments ...}
+
+Item Controller
+
+commands:
+
+  add
+    Add an item to the vault.
+
+  get
+    Get an item from the vault.
+
+positional arguments:
+  name                  The item name.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               toggle debug output
+  --quiet               suppress all output
+  -a ACCOUNT, --account ACCOUNT
+                        Use this account to authenticate
+  -v VAULT, --vault VAULT
+                        Use this vault
+  -t TAG, --tag TAG     Add a tag to the item
+  --tags TAGS           Add multiple separated comma tags
+  --content CONTENT     Add content to the item
+```

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ An CLI for Cabinet.
 ## Installation
 
 ```
-pip install -r requiremen.txt
+pip install -r requirements.txt
 ```
 
 ## Configuration
 
 By default, the cli will read the configuration file located on `~/.config/cabinet/cli.ini`. So far, it only the following parameters are configurable:
 
-* `account` : The users account.
+* `account` : The user's account.
 * `default_vault` : The default vault name to be used if none is specified.
 
 The configuration file (`cli.ini`) looks like:

--- a/cli.py
+++ b/cli.py
@@ -61,16 +61,16 @@ class CabinetWrapper:
 
         if vault_name:
             self.vault_name = vault_name
-        elif self.config['default_vault']:
-            self.vault_name = self.config['default_vault']
+        elif self.config['Credentials']['default_vault']:
+            self.vault_name = self.config['Credentials']['default_vault']
         else:
             print('Vault not specified')
             exit()
 
         if account_id:
             self.account_id = account_id
-        elif self.config['account']:
-            self.account_id = self.config['account']
+        elif self.config['Credentials']['account']:
+            self.account_id = self.config['Credentials']['account']
         else:
             print('Account not specified')
             exit()

--- a/cli.py
+++ b/cli.py
@@ -168,14 +168,24 @@ def tuple_type(value):
         raise argparse.argumenttypeerror("coordinates must be x,y,z")
 
 ###############################################################################
+# TODO: Refactor this to avoid having this global var
+
+COMMON_ARGS = [
+    (['-a', '--account'],
+        dict(help='Use this account to authenticate', action='store')),
+    (['-v', '--vault'],
+        dict(help='Use this vault', action='store'))
+]
+
+###############################################################################
 
 
 class CabinetController(CementBaseController):
     class Meta:
         label = 'base'
         description = "Cabinet's cli client for managing vaults."
-        arguments = [
-            (['-v', '--version'], dict(action='version', version=BANNER))
+        arguments = COMMON_ARGS + [
+            (['--version'], dict(action='version', version=BANNER))
         ]
 
     @expose(hide=True)
@@ -189,13 +199,9 @@ class ItemController(CementBaseController):
         label = 'item'
         stacked_on = 'base'
         stacked_type = 'nested'
-        arguments = [
+        arguments = COMMON_ARGS + [
             (['name'],
              dict(help='The item name.', action='store')),
-            (['-a', '--account'],
-             dict(help='Use this account to authenticate', action='store')),
-            (['-v', '--vault'],
-             dict(help='Use this vault', action='store')),
             (['-t', '--tag'],
              dict(help='Add a tag to the item', action='append')),
             (['--tags'],
@@ -256,11 +262,7 @@ class SearchController(CementBaseController):
         label = 'search'
         stacked_on = 'base'
         stacked_type = 'nested'
-        arguments = [
-            (['-a', '--account'],
-             dict(help='Use this account to authenticate', action='store')),
-            (['-v', '--vault'],
-             dict(help='Use this vault', action='store')),
+        arguments = COMMON_ARGS + [
             (['-s', '--show-tags'],
              dict(help='Show items with tags.', action='store_true')),
             (['-t', '--tag'],

--- a/cli.py
+++ b/cli.py
@@ -61,7 +61,8 @@ class CabinetWrapper:
 
         if vault_name:
             self.vault_name = vault_name
-        elif self.config['Credentials']['default_vault']:
+        elif 'Credentials' in self.config and 'default_vault' in \
+                                              self.config['Credentials']:
             self.vault_name = self.config['Credentials']['default_vault']
         else:
             print('Vault not specified')
@@ -69,7 +70,8 @@ class CabinetWrapper:
 
         if account_id:
             self.account_id = account_id
-        elif self.config['Credentials']['account']:
+        elif 'Credentials' in self.config and 'account' in \
+                                              self.config['Credentials']:
             self.account_id = self.config['Credentials']['account']
         else:
             print('Account not specified')


### PR DESCRIPTION
This PR adds support for:
* Using the configuration file located at `~/.config/cabinet/cli.ini`
* Setting a default vault name in config file.
* Setting an account in config file.
* Prompting for the account password

Also it adds the arguments for passing the `account` and a `vault` name. If they're passed, then they will be prioritized over the values set in the config file.