### PR TITLE
Separate wrapper

### DIFF
--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -17,6 +17,18 @@ class CabinetWrapper:
     """
 
     def __init__(self, vault_name=None, account_id=None):
+        """
+        Initialize the cabinet instance using the given vault/account or from
+        the configuration file if you don't specify them.
+
+        This will prompt for the account password to open the vault.
+
+        :param vault_name: The name of the vault
+        :type: str
+
+        :param account_id:
+        :type: str
+        """
         join = os.path.join
         self.base_path = join(os.path.expanduser('~'), '.config', 'cabinet')
         self.config_file = join(self.base_path, 'cli.ini')
@@ -127,8 +139,14 @@ class CabinetWrapper:
         """
         Add an item to the vault.
 
-        :param item: The item to be added.
-        :type: Dictionary
+        :param item: The item's name
+        :type: str
+
+        :param tags: The item's tags
+        :type: list
+
+        :param content: The item's contents
+        :type: any
         """
         if self._ready:
             item = {
@@ -139,6 +157,15 @@ class CabinetWrapper:
             self.cab.add(item)
 
     def search(self, tags, show_tags):
+        """
+        Search for items with the given tags.
+
+        :param tags: the tags to search for
+        :type tags: list
+
+        :param show_tags: whether we should show the tags or not
+        :type show_tags: bool
+        """
         if self._ready:
             item_list = self.get_by_tags(tags)
             print("The following items were found:")

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -102,7 +102,7 @@ class CabinetWrapper:
         """
         return self.cab.get_all()
 
-    def get_item(self, name):
+    def get_item(self, vault_name, account_id, name):
         """
         Get an item from the vault.
 
@@ -112,6 +112,13 @@ class CabinetWrapper:
         :returns: The item with the specified name.
         :type: Dictionary
         """
+        if self.load_credentials(vault_name, account_id):
+            item = self.cab.get_item(name)
+            if item:
+                print(item)
+            else:
+                print('Item with name "{0}" not found!'.format(name))
+
         return self.cab.get(name)
 
     def add_item(self, vault_name, account_id, name, tags, content):

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -114,14 +114,20 @@ class CabinetWrapper:
         """
         return self.cab.get(name)
 
-    def add_item(self, item):
+    def add_item(self, vault_name, account_id, name, tags, content):
         """
         Add an item to the vault.
 
         :param item: The item to be added.
         :type: Dictionary
         """
-        self.cab.add(item)
+        if self.load_credentials(vault_name, account_id):
+            item = {
+                'name': name,
+                'tags': tags,
+                'content': content
+            }
+            self.cab.add(item)
 
     def search(self, vault_name, account_id, tags, show_tags):
         if self.load_credentials(vault_name, account_id):

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -122,3 +122,12 @@ class CabinetWrapper:
         :type: Dictionary
         """
         self.cab.add(item)
+
+    def search(self, vault_name, account_id, tags, show_tags):
+        if self.load_credentials(vault_name, account_id):
+            item_list = self.get_by_tags(tags)
+            print("The following items were found:")
+            tag_tpl = " tagged with {1}" if show_tags else ''
+            for item in item_list:
+                print(('\t-"{0}"' + tag_tpl).format(item['name'],
+                                                    item['tags']))

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from sys import exit
+from getpass import getpass
+from configparser import ConfigParser
+
+from cabinet import Cabinet
+
+
+class CabinetWrapper:
+    """
+    A wrapper to easely use the cabinet library.
+
+    TODO: In the future we should try moving this all to the library.
+    """
+
+    def __init__(self):
+        join = os.path.join
+        self.base_path = join(os.path.expanduser('~'), '.config', 'cabinet')
+        self.config_file = join(self.base_path, 'cli.ini')
+        self.secrets_path = join(self.base_path, 'secrets')
+        self.vault_path = join(self.base_path, 'vaults')
+        self.config = ConfigParser()
+        self.config.read(self.config_file)
+
+    def load_credentials(self, vault_name=None, account_id=None):
+        """
+        It loads the vault name and account id from the configuration, then
+        it overrides the configuration with the cli options (if entered).
+        Finally, it prompts for the account password and opens the vault.
+
+        Params:
+        :param vault_name: The name of the vault
+        :type: String
+        :param account_id:
+        :type: String
+
+        TODO: Move the print and die to utils
+        """
+
+        if vault_name:
+            self.vault_name = vault_name
+        elif 'Credentials' in self.config and 'default_vault' in \
+                                              self.config['Credentials']:
+            self.vault_name = self.config['Credentials']['default_vault']
+        else:
+            print('Vault not specified')
+            exit()
+
+        if account_id:
+            self.account_id = account_id
+        elif 'Credentials' in self.config and 'account' in \
+                                              self.config['Credentials']:
+            self.account_id = self.config['Credentials']['account']
+        else:
+            print('Account not specified')
+            exit()
+
+        self.password = getpass()
+        return self.open_vault(self.account_id, self.password, self.vault_name)
+
+    def open_vault(self, account_id, password, vault_name):
+        """
+        Open the vault identified by the vault_name.
+
+        Params:
+        :param account_id:
+        :type: String
+        :param password:
+        :type: String
+        :param vault_name: The name of the vault
+        :type: String
+
+        TODO: Implement account_id/password/vault validation and opening
+        """
+
+        self.cab = Cabinet(account_id, password, self.secrets_path)
+        self.cab.open(vault_name, self.vault_path)
+
+        # TODO: Add open check. For this, the vault should verify keys
+        return True
+
+    def get_by_tags(self, tags):
+        """
+        Get all the items from the vault without the 'content' (i.e: only name
+        and tags) that matches all the given tags.
+
+        :returns: The list of items
+        :type: List of Dictionaries.
+        """
+        return self.cab.get_by_tags(tags)
+
+    def get_all(self):
+        """
+        Get all the items from the vault without the 'content' (i.e: only name
+        and tags).
+
+        :returns: The list of items
+        :type: List of Dictionaries.
+        """
+        return self.cab.get_all()
+
+    def get_item(self, name):
+        """
+        Get an item from the vault.
+
+        :param name: The name of the item to recover.
+        :type: String
+
+        :returns: The item with the specified name.
+        :type: Dictionary
+        """
+        return self.cab.get(name)
+
+    def add_item(self, item):
+        """
+        Add an item to the vault.
+
+        :param item: The item to be added.
+        :type: Dictionary
+        """
+        self.cab.add(item)

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -16,7 +16,7 @@ class CabinetWrapper:
     TODO: In the future we should try moving this all to the library.
     """
 
-    def __init__(self):
+    def __init__(self, vault_name=None, account_id=None):
         join = os.path.join
         self.base_path = join(os.path.expanduser('~'), '.config', 'cabinet')
         self.config_file = join(self.base_path, 'cli.ini')
@@ -25,7 +25,9 @@ class CabinetWrapper:
         self.config = ConfigParser()
         self.config.read(self.config_file)
 
-    def load_credentials(self, vault_name=None, account_id=None):
+        self._ready = self._load_credentials(vault_name, account_id)
+
+    def _load_credentials(self, vault_name=None, account_id=None):
         """
         It loads the vault name and account id from the configuration, then
         it overrides the configuration with the cli options (if entered).
@@ -102,7 +104,7 @@ class CabinetWrapper:
         """
         return self.cab.get_all()
 
-    def get_item(self, vault_name, account_id, name):
+    def get_item(self, name):
         """
         Get an item from the vault.
 
@@ -112,23 +114,23 @@ class CabinetWrapper:
         :returns: The item with the specified name.
         :type: Dictionary
         """
-        if self.load_credentials(vault_name, account_id):
+        if self._ready:
             item = self.cab.get_item(name)
             if item:
                 print(item)
             else:
                 print('Item with name "{0}" not found!'.format(name))
 
-        return self.cab.get(name)
+            return self.cab.get(name)
 
-    def add_item(self, vault_name, account_id, name, tags, content):
+    def add_item(self, name, tags, content):
         """
         Add an item to the vault.
 
         :param item: The item to be added.
         :type: Dictionary
         """
-        if self.load_credentials(vault_name, account_id):
+        if self._ready:
             item = {
                 'name': name,
                 'tags': tags,
@@ -136,8 +138,8 @@ class CabinetWrapper:
             }
             self.cab.add(item)
 
-    def search(self, vault_name, account_id, tags, show_tags):
-        if self.load_credentials(vault_name, account_id):
+    def search(self, tags, show_tags):
+        if self._ready:
             item_list = self.get_by_tags(tags)
             print("The following items were found:")
             tag_tpl = " tagged with {1}" if show_tags else ''

--- a/cli.py
+++ b/cli.py
@@ -113,12 +113,7 @@ class ItemController(CementBaseController):
         if name:
             self.app.log.debug('Looking for item with name "{0}"'.format(name))
             cab = CabinetWrapper()
-            if cab.load_credentials(vault_name, account_id):
-                item = cab.get_item(name)
-                if item:
-                    print(item)
-                else:
-                    print('Item with name "{0}" not found!'.format(name))
+            cab.get(vault_name, account_id, name)
 
     @expose(help="Add an item to the vault.")
     def add(self):

--- a/cli.py
+++ b/cli.py
@@ -10,137 +10,19 @@
 # TODO:
 #   - Refactor the code to move each class, utils to its own module.
 
-import os
 import argparse
 
-from sys import exit
-from getpass import getpass
-from configparser import ConfigParser
 from cement.core.foundation import CementApp
 from cement.core.controller import CementBaseController, expose
 
-from cabinet import Cabinet
+from cabinet_wrapper import CabinetWrapper
+
 
 VERSION = '0.0.1'
 BANNER = """
 Cabinet command line v{0}
 GNU GENERAL PUBLIC LICENSE
 """.format(VERSION)
-
-
-class CabinetWrapper:
-    """
-    A wrapper to easely use the cabinet library.
-
-    TODO: In the future we should try moving this all to the library.
-    """
-
-    def __init__(self):
-        join = os.path.join
-        self.base_path = join(os.path.expanduser('~'), '.config', 'cabinet')
-        self.config_file = join(self.base_path, 'cli.ini')
-        self.secrets_path = join(self.base_path, 'secrets')
-        self.vault_path = join(self.base_path, 'vaults')
-        self.config = ConfigParser()
-        self.config.read(self.config_file)
-
-    def load_credentials(self, vault_name=None, account_id=None):
-        """
-        It loads the vault name and account id from the configuration, then
-        it overrides the configuration with the cli options (if entered).
-        Finally, it prompts for the account password and opens the vault.
-
-        Params:
-        :param vault_name: The name of the vault
-        :type: String
-        :param account_id:
-        :type: String
-
-        TODO: Move the print and die to utils
-        """
-
-        if vault_name:
-            self.vault_name = vault_name
-        elif 'Credentials' in self.config and 'default_vault' in \
-                                              self.config['Credentials']:
-            self.vault_name = self.config['Credentials']['default_vault']
-        else:
-            print('Vault not specified')
-            exit()
-
-        if account_id:
-            self.account_id = account_id
-        elif 'Credentials' in self.config and 'account' in \
-                                              self.config['Credentials']:
-            self.account_id = self.config['Credentials']['account']
-        else:
-            print('Account not specified')
-            exit()
-
-        self.password = getpass()
-        return self.open_vault(self.account_id, self.password, self.vault_name)
-
-    def open_vault(self, account_id, password, vault_name):
-        """
-        Open the vault identified by the vault_name.
-
-        Params:
-        :param account_id:
-        :type: String
-        :param password:
-        :type: String
-        :param vault_name: The name of the vault
-        :type: String
-
-        TODO: Implement account_id/password/vault validation and opening
-        """
-
-        self.cab = Cabinet(account_id, password, self.secrets_path)
-        self.cab.open(vault_name, self.vault_path)
-
-        # TODO: Add open check. For this, the vault should verify keys
-        return True
-
-    def get_by_tags(self, tags):
-        """
-        Get all the items from the vault without the 'content' (i.e: only name
-        and tags) that matches all the given tags.
-
-        :returns: The list of items
-        :type: List of Dictionaries.
-        """
-        return self.cab.get_by_tags(tags)
-
-    def get_all(self):
-        """
-        Get all the items from the vault without the 'content' (i.e: only name
-        and tags).
-
-        :returns: The list of items
-        :type: List of Dictionaries.
-        """
-        return self.cab.get_all()
-
-    def get_item(self, name):
-        """
-        Get an item from the vault.
-
-        :param name: The name of the item to recover.
-        :type: String
-
-        :returns: The item with the specified name.
-        :type: Dictionary
-        """
-        return self.cab.get(name)
-
-    def add_item(self, item):
-        """
-        Add an item to the vault.
-
-        :param item: The item to be added.
-        :type: Dictionary
-        """
-        self.cab.add(item)
 
 
 # TODO: Move the types out of this file, to a type folder/file. ###############

--- a/cli.py
+++ b/cli.py
@@ -137,12 +137,7 @@ class ItemController(CementBaseController):
 
         if name:
             cab = CabinetWrapper()
-            if cab.load_credentials(vault_name, account_id):
-                cab.add_item({
-                    'name': name,
-                    'tags': tags,
-                    'content': content_obj
-                })
+            cab.add_item(vault_name, account_id, name, tags, content_obj)
         else:
             print('Insufficient arguments!')
 

--- a/cli.py
+++ b/cli.py
@@ -112,8 +112,8 @@ class ItemController(CementBaseController):
         name = self.app.pargs.name
         if name:
             self.app.log.debug('Looking for item with name "{0}"'.format(name))
-            cab = CabinetWrapper()
-            cab.get(vault_name, account_id, name)
+            cab = CabinetWrapper(vault_name, account_id)
+            cab.get(name)
 
     @expose(help="Add an item to the vault.")
     def add(self):
@@ -131,8 +131,8 @@ class ItemController(CementBaseController):
             content_obj[key] = value
 
         if name:
-            cab = CabinetWrapper()
-            cab.add_item(vault_name, account_id, name, tags, content_obj)
+            cab = CabinetWrapper(vault_name, account_id)
+            cab.add_item(name, tags, content_obj)
         else:
             print('Insufficient arguments!')
 
@@ -167,8 +167,8 @@ class SearchController(CementBaseController):
             tags = [] if not self.app.pargs.tag else self.app.pargs.tag
         show_tags = self.app.pargs.show_tags
 
-        cab = CabinetWrapper()
-        cab.search(vault_name, account_id, tags, show_tags)
+        cab = CabinetWrapper(vault_name, account_id)
+        cab.search(tags, show_tags)
 
 
 class MyApp(CementApp):

--- a/cli.py
+++ b/cli.py
@@ -175,14 +175,10 @@ class SearchController(CementBaseController):
         tags = self.app.pargs.tags
         if not tags:
             tags = [] if not self.app.pargs.tag else self.app.pargs.tag
-        tag_tpl = " tagged with {1}" if self.app.pargs.show_tags else ''
+        show_tags = self.app.pargs.show_tags
+
         cab = CabinetWrapper()
-        if cab.load_credentials(vault_name, account_id):
-            item_list = cab.get_by_tags(tags)
-            print("The following items was found:")
-            for item in item_list:
-                print(('\t-"{0}"' + tag_tpl).format(item['name'],
-                                                    item['tags']))
+        cab.search(vault_name, account_id, tags, show_tags)
 
 
 class MyApp(CementApp):


### PR DESCRIPTION
The goal of this PR is to separate all the possible logic that is not "doing CLI stuff and handling parameters".
After this, a migration to other cli framework will be just a couple of copy/pasted lines.

I've changed how we use credentials as well and moved them to the constructor to reduce lines when using the wrapper.