### PR TITLE
Add raw content from stdin and improve item printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Usage: cab add [OPTIONS] NAME
 Options:
   -t, --tag TEXT      Specify tags for the item
   -c, --content TEXT  The item content
-  -e, --edit-content  The item content
+  -i, --from-stdin    Get the content from stdin
+  -e, --use-editor    Use the default editor for entering the content
   --help              Show this message and exit.
 
 ➜ cab get --help
@@ -72,6 +73,7 @@ Usage: cab get [OPTIONS] NAME
   Get an item from cabinet
 
 Options:
+  -a, --all  Print the item with all its information (tags and name)
   --help  Show this message and exit.
 
 ➜ cab search --help

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -114,22 +114,30 @@ class CabinetWrapper:
         """
         return self.cab.get_all()
 
-    def get_item(self, name):
+    def get_item(self, name, print_all):
         """
         Get an item from the vault.
 
         :param name: The name of the item to recover.
         :type: String
+        :param print_all: Print all the information related to the item.
+        :type: Boolean
 
         :returns: The item with the specified name.
         :type: Dictionary
         """
         if self._ready:
             item = self.cab.get(name)
-            if item:
-                print(item)
-            else:
+
+            if not item:
                 print('Item with name "{0}" not found!'.format(name))
+                return
+
+            if print_all:
+                print("Name: {0}\nTags: {1}\nContent: {2}"
+                      .format(name, item['tags'], item['content']))
+            else:
+                print(item['content'])
 
     def add_item(self, name, tags, content):
         """

--- a/cli.py
+++ b/cli.py
@@ -67,13 +67,15 @@ def add(ctx, name, tags, content, from_stdin, editor):
 
 @cli.command()
 @click.argument('name')
+@click.option('print_all', '-a', '--all', is_flag=True,
+              help='Print the item with all its information (tags and name)')
 @click.pass_context
-def get(ctx, name):
+def get(ctx, name, print_all):
     """Get an item from cabinet"""
     account = ctx.obj.get('account')
     vault = ctx.obj.get('vault')
     cab = CabinetWrapper(account, vault)
-    cab.get_item(name)
+    cab.get_item(name, print_all)
 
 
 @cli.command()

--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import click
 
+from sys import stdin
 from utils import get_content_from_editor
 
 from cabinet_wrapper import CabinetWrapper
@@ -32,17 +33,23 @@ def cli(ctx, account, vault):
               help='Specify tags for the item')
 @click.option('content', '-c', '--content',
               help='The item content')
+@click.option('from_stdin', '-i', '--from-stdin', is_flag=True,
+              help="Get the content from stdin")
 @click.option('editor', '-e', '--use-editor', is_flag=True,
               help="Use the default editor for entering the content")
 @click.pass_context
-def add(ctx, name, tags, content, editor):
+def add(ctx, name, tags, content, from_stdin, editor):
     """Add an item to cabinet"""
     click.echo('>> Add item')
     click.echo('Name: {0}'.format(name))
     click.echo('Content: {0}'.format(content))
 
     if not content:
-        if editor:
+        if from_stdin:
+            content = ""
+            for line in stdin:
+                content = content + line
+        elif editor:
             content = get_content_from_editor()
             print("Content from editor:", content)
         else:


### PR DESCRIPTION
This PR includes:
- Support for getting the item content from stdin when adding a new item. This implements the feature described in #7.
- Modify the getter to no longer print the item in JSON format. By default it will print the item content only, and all the date if `-a | --all` is specified.