### PR TITLE
Add `tag` command to get all the tags

### DIFF
--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -104,6 +104,13 @@ class CabinetWrapper:
         """
         return self.cab.get_by_tags(tags)
 
+    def get_tags(self):
+        """
+        Get all the tags from the vault.
+        """
+        tags = self.cab.get_tags()
+        print("Tags:", ','.join(tags))
+
     def get_all(self):
         """
         Get all the items from the vault without the 'content' (i.e: only name

--- a/cli.py
+++ b/cli.py
@@ -51,7 +51,8 @@ def add(ctx, name, tags, content, from_stdin, editor):
                 content = content + line
         elif editor:
             content = get_content_from_editor()
-            print("Content from editor:", content)
+            print("Content from editor:")
+            print(content)
         else:
             click.echo("Error: you need to specify the content")
             return
@@ -82,6 +83,16 @@ def get(ctx, name, print_all):
 def rm():
     """[not implemented] Remove an item from cabinet"""
     click.echo('Sorry! not implemented yet.')
+
+
+@cli.command()
+@click.pass_context
+def tags(ctx):
+    """Get tags from cabinet"""
+    account = ctx.obj.get('account')
+    vault = ctx.obj.get('vault')
+    cab = CabinetWrapper(account, vault)
+    cab.get_tags()
 
 
 @cli.command()


### PR DESCRIPTION
I don't find this feature particularly useful, but on the lib and the ui it will, so I though on having it here, just in case.

This needs https://github.com/cabinet/cabinet-lib/pull/7 to work.