### PR TITLE
Refactor edition

### DIFF
--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -46,9 +46,9 @@ class CabinetWrapper:
 
         Params:
         :param vault_name: The name of the vault
-        :type: String
+        :type: str
         :param account_id:
-        :type: String
+        :type: str
 
         TODO: Move the print and die to utils
         """
@@ -79,11 +79,11 @@ class CabinetWrapper:
 
         Params:
         :param account_id:
-        :type: String
+        :type: str
         :param password:
-        :type: String
+        :type: str
         :param vault_name: The name of the vault
-        :type: String
+        :type: str
 
         TODO: Implement account_id/password/vault validation and opening
         """
@@ -100,7 +100,7 @@ class CabinetWrapper:
         and tags) that matches all the given tags.
 
         :returns: The list of items
-        :type: List of Dictionaries.
+        :type: list of dicts.
         """
         return self.cab.get_by_tags(tags)
 
@@ -117,7 +117,7 @@ class CabinetWrapper:
         and tags).
 
         :returns: The list of items
-        :type: List of Dictionaries.
+        :type: list of dicts.
         """
         return self.cab.get_all()
 
@@ -126,12 +126,12 @@ class CabinetWrapper:
         Get an item from the vault.
 
         :param name: The name of the item to recover.
-        :type: String
+        :type: str
         :param print_all: Print all the information related to the item.
-        :type: Boolean
+        :type: bool
 
         :returns: The item with the specified name.
-        :type: Dictionary
+        :type: dict
         """
         if self._ready:
             item = self.cab.get(name)
@@ -151,10 +151,10 @@ class CabinetWrapper:
         Get the content of an item from the vault.
 
         :param name: The name of the item to recover.
-        :type: String
+        :type: str
 
         :returns: The item's content.
-        :type: String
+        :type: str
         """
         if self._ready:
             item = self.cab.get(name)

--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -146,6 +146,25 @@ class CabinetWrapper:
             else:
                 print(item['content'])
 
+    def get_item_content(self, name):
+        """
+        Get the content of an item from the vault.
+
+        :param name: The name of the item to recover.
+        :type: String
+
+        :returns: The item's content.
+        :type: String
+        """
+        if self._ready:
+            item = self.cab.get(name)
+
+            if not item:
+                print('Item with name "{0}" not found!'.format(name))
+                return
+
+            return item['content']
+
     def add_item(self, name, tags, content):
         """
         Add an item to the vault.

--- a/cli.py
+++ b/cli.py
@@ -68,6 +68,46 @@ def add(ctx, name, tags, content, from_stdin, editor):
 
 @cli.command()
 @click.argument('name')
+@click.option('tags', '-t', '--tag', multiple=True,
+              help='Specify tags for the item')
+@click.option('content', '-c', '--content',
+              help='The item content')
+@click.option('from_stdin', '-i', '--from-stdin', is_flag=True,
+              help="Get the content from stdin")
+@click.option('editor', '-e', '--use-editor', is_flag=True,
+              help="Use the default editor for entering the content")
+@click.pass_context
+def update(ctx, name, tags, content, from_stdin, editor):
+    """Add an item to cabinet"""
+    click.echo('>> Edit item')
+    click.echo('Name: {0}'.format(name))
+
+    account = ctx.obj.get('account')
+    vault = ctx.obj.get('vault')
+    cab = CabinetWrapper(account, vault)
+
+    if not content:
+        if from_stdin:
+            content = ""
+            for line in stdin:
+                content = content + line
+        elif editor:
+            current_content = cab.get_item_content(name)
+            content = get_content_from_editor(current_content)
+            print("Content from editor:")
+            print(content)
+        else:
+            click.echo("Error: you need to specify the content")
+            return
+
+    if tags:
+        click.echo('Tags: %s' % ', '.join(tags))
+
+    cab.update(name, tags, content)
+
+
+@cli.command()
+@click.argument('name')
 @click.argument('new_name')
 @click.pass_context
 def rename(ctx, name, new_name):

--- a/cli.py
+++ b/cli.py
@@ -93,17 +93,19 @@ def update(ctx, name, tags, content, from_stdin, editor):
                 content = content + line
         elif editor:
             current_content = cab.get_item_content(name)
-            content = get_content_from_editor(current_content)
-            print("Content from editor:")
-            print(content)
+            if current_content:
+                content = get_content_from_editor(current_content)
+                print("Content from editor:")
+                print(content)
         else:
             click.echo("Error: you need to specify the content")
             return
 
-    if tags:
-        click.echo('Tags: %s' % ', '.join(tags))
+    if content:
+        if tags:
+            click.echo('Tags: %s' % ', '.join(tags))
 
-    cab.update(name, tags, content)
+        cab.update(name, tags, content)
 
 
 @cli.command()

--- a/cli.py
+++ b/cli.py
@@ -37,10 +37,8 @@ def cli(ctx, account, vault):
               help="Get the content from stdin")
 @click.option('editor', '-e', '--use-editor', is_flag=True,
               help="Use the default editor for entering the content")
-@click.option('update', '-u', '--update', is_flag=True,
-              help="Update the contents of an existing item")
 @click.pass_context
-def add(ctx, name, tags, content, from_stdin, editor, update):
+def add(ctx, name, tags, content, from_stdin, editor):
     """Add an item to cabinet"""
     click.echo('>> Add item')
     click.echo('Name: {0}'.format(name))
@@ -65,10 +63,7 @@ def add(ctx, name, tags, content, from_stdin, editor, update):
     account = ctx.obj.get('account')
     vault = ctx.obj.get('vault')
     cab = CabinetWrapper(account, vault)
-    if update:
-        cab.update(name, tags, content)
-    else:
-        cab.add_item(name, tags, content)
+    cab.add_item(name, tags, content)
 
 
 @cli.command()

--- a/cli.py
+++ b/cli.py
@@ -78,7 +78,7 @@ def add(ctx, name, tags, content, from_stdin, editor):
               help="Use the default editor for entering the content")
 @click.pass_context
 def update(ctx, name, tags, content, from_stdin, editor):
-    """Add an item to cabinet"""
+    """Update an existing item"""
     click.echo('>> Edit item')
     click.echo('Name: {0}'.format(name))
 

--- a/utils.py
+++ b/utils.py
@@ -8,15 +8,29 @@ import tempfile
 from configparser import ConfigParser
 
 
-def get_content_from_editor():
+def get_content_from_editor(current_content=None):
+    """
+    Get the content from the default editor. If there is a current content, it
+    loads it within the editor.
+
+    :param current_content: The current item's content.
+    :type: String
+
+    :returns: The updated item's content.
+    :type: String
+    """
     t = tempfile.NamedTemporaryFile(delete=True)
+    if current_content:
+        t.write(current_content.encode('utf-8'))
+        t.flush()
+
     try:
         editor = os.environ['EDITOR']
     except KeyError:
         editor = 'nano'
     subprocess.call([editor, t.name])
 
-    # content = t.read().splitlines()
+    t.seek(0)
     b_content = t.read()
     t.close()
 

--- a/utils.py
+++ b/utils.py
@@ -14,10 +14,10 @@ def get_content_from_editor(current_content=None):
     loads it within the editor.
 
     :param current_content: The current item's content.
-    :type: String
+    :type: str
 
     :returns: The updated item's content.
-    :type: String
+    :type: str
     """
     t = tempfile.NamedTemporaryFile(delete=True)
     if current_content:


### PR DESCRIPTION
- Update the util function "get_content_from_editor" to be able to
load the item content to the editor if any.
- Update the cabinet wrapper by adding the function "get_item_content".
This function allows to get the items content without printing anything
to the stdout unless there is some error.
- Remove the -u option from the subcommand "add". Updating should
have its own subcommand.
- Add the subcommand "edit" with support for loading the current item content
within the default editor.