### PR TITLE
Do not clear tags when updating content

### DIFF
--- a/cabinet_wrapper.py
+++ b/cabinet_wrapper.py
@@ -165,6 +165,25 @@ class CabinetWrapper:
 
             return item['content']
 
+    def get_item_tags(self, name):
+        """
+        Get the tags of an item from the vault.
+
+        :param name: The name of the item to recover.
+        :type: str
+
+        :returns: The item's tags.
+        :type: list
+        """
+        if self._ready:
+            item = self.cab.get(name)
+
+            if not item:
+                print('Item with name "{0}" not found!'.format(name))
+                return
+
+            return item['tags']
+
     def add_item(self, name, tags, content):
         """
         Add an item to the vault.

--- a/cli.py
+++ b/cli.py
@@ -102,8 +102,9 @@ def update(ctx, name, tags, content, from_stdin, editor):
             return
 
     if content:
-        if tags:
-            click.echo('Tags: %s' % ', '.join(tags))
+        if not tags:
+            tags = cab.get_item_tags(name)
+        click.echo('Tags: %s' % ', '.join(tags))
 
         cab.update(name, tags, content)
 


### PR DESCRIPTION
Only do so when the user used the `--tags` option.